### PR TITLE
fix typo

### DIFF
--- a/publish/issue7/issue-7-1-migrant.md
+++ b/publish/issue7/issue-7-1-migrant.md
@@ -314,7 +314,7 @@
 
 从 iOS 6 和 OS X 10.8 开始，新建的字典可以使用一个预先生成好的键集，使用 `sharedKeySetForKeys:` 从一个数组中创建键集，然后用 `dictionaryWithSharedKeySet:` 创建字典。共享键集会复用对象，以节省内存。根据 [Foundation Release Notes](https://developer.apple.com/library/mac/releasenotes/Foundation/RN-FoundationOlderNotes/)，`sharedKeySetForKeys:` 中会计算一个最小完美哈希，这个哈希值可以取代字典查找过程中探索循环的需要，因此使键的访问更快。
 
-虽然在我们有限的测试中没有法线苹果在 `NSJSONSerialization` 中使用这个特性，但毫无疑问，在处理 JSON 的解析工作时这个特性可以发挥得淋漓尽致。(使用共享键集创建的字典是 `NSSharedKeyDictionary` 的子类；通常的字典是 `__NSDictionaryI` / `__NSDictionaryM`，I / M 表明可变性；可变和不可变的的字典在 toll-free 桥接后对应的都是 `_NSCFDictionary` 类。)
+虽然在我们有限的测试中没有发现苹果在 `NSJSONSerialization` 中使用这个特性，但毫无疑问，在处理 JSON 的解析工作时这个特性可以发挥得淋漓尽致。(使用共享键集创建的字典是 `NSSharedKeyDictionary` 的子类；通常的字典是 `__NSDictionaryI` / `__NSDictionaryM`，I / M 表明可变性；可变和不可变的的字典在 toll-free 桥接后对应的都是 `_NSCFDictionary` 类。)
 
 **有趣的细节：**共享键字典**始终是可变的**，即使对它们执行了”copy”命令后也是。这个行为文档中并没有说明，但很容易被测试:
 

--- a/publish/issue9/issue-9-3-YCFlame.md
+++ b/publish/issue9/issue-9-3-YCFlame.md
@@ -107,7 +107,7 @@ self.label.text = [NSString localizedStringWithFormat:localizedString, completed
 在翻译的时候经常需要对其中的格式化占位符进行顺序调整以符合语法，幸运的是我们可以在字符串文件中轻松地搞定：
 
 ```
-"activity-profile.label.run %lu out of %lu completed" = "Von %2$lu Läufen hast du %$1lu absolviert";
+"activity-profile.label.run %lu out of %lu completed" = "Von %2$lu Läufen hast du %1$lu absolviert";
 ```
 
 上面的德文翻译得不是非常好，只是单纯用来说明调换占位符顺序的功能而已。


### PR DESCRIPTION
法线->发现

本地化一文中，并非翻译错误，而是对照原文阅读时，发现有一处符号不一致。