### PR TITLE
引用的跳转链接修复

### DIFF
--- a/publish/issue1/issue-1-1-tang3w.md
+++ b/publish/issue1/issue-1-1-tang3w.md
@@ -177,7 +177,7 @@ View controllers 通常是 iOS 项目中最大的文件，并且它们包含了�
    [6]: https://github.com/objcio/issue-1-lighter-view-controllers/blob/master/PhotoData/ArrayDataSource.h
    [7]: https://github.com/objcio/issue-1-lighter-view-controllers/blob/master/PhotoData/PhotoCell.xib
    [8]: http://objccn.io/issue-1
-   [11]: http://developer.apple.com/library/ios/#featuredarticles/ViewControllerPGforiPhoneOS/BasicViewControllers/BasicViewControllers.html
+   [11]: https://developer.apple.com/library/content/featuredarticles/ViewControllerPGforiPhoneOS/
    [12]: http://developer.apple.com/library/mac/#documentation/General/Conceptual/DevPedia-CocoaCore/ControllerObject.html
    [13]: http://subjective-objective-c.blogspot.de/2011/08/writing-high-quality-view-controller.html
    [14]: http://programmers.stackexchange.com/questions/184396/mvcs-model-view-controller-store


### PR DESCRIPTION
**Issue 1-1** 
引用【11】View Controller Programming Guide for iOS，原来的链接应该是失效了，现在通过在苹果开发者中心查找到的介绍View Controller文档，现在修复